### PR TITLE
Feature: default location

### DIFF
--- a/src/ui/settings/settings.ts
+++ b/src/ui/settings/settings.ts
@@ -53,7 +53,7 @@ export class SettingsModal extends Modal {
 		new Setting(this.contentEl)
 			.setName("Default task location")
 			.setDesc(
-				"In what .md file should new tasks go? Leave blank to choose each time a new task is added. Start with a forward slash (/) for a full folder path. Otherwise, tasks go to specified path in the current folder."
+				'Specify the .md file for new tasks. Leave blank to choose each time a new task is added. Start with a forward slash (/) for a full folder path. Otherwise, tasks go to the specified path in the current folder. The path must not contain these characters: * " \\ / < > : | ?'
 			)
 			.addText((text) => {
 				text.setPlaceholder("Tasks.md")

--- a/src/ui/settings/settings.ts
+++ b/src/ui/settings/settings.ts
@@ -51,6 +51,19 @@ export class SettingsModal extends Modal {
 			});
 
 		new Setting(this.contentEl)
+			.setName("Default task location")
+			.setDesc(
+				"Where should new tasks go? Use an .md file (leave blank to decide each time)."
+			)
+			.addText((text) => {
+				text.setPlaceholder("folder/file.md")
+					.setValue(this.settings.defaultTaskPath ?? "")
+					.onChange((value) => {
+						this.settings.defaultTaskPath = value;
+					});
+			});
+
+		new Setting(this.contentEl)
 			.setName("Show filepath")
 			.setDesc("Show the filepath on each task in Kanban?")
 			.addToggle((toggle) => {

--- a/src/ui/settings/settings.ts
+++ b/src/ui/settings/settings.ts
@@ -53,10 +53,10 @@ export class SettingsModal extends Modal {
 		new Setting(this.contentEl)
 			.setName("Default task location")
 			.setDesc(
-				"Where should new tasks go? Use an .md file (leave blank to decide each time)."
+				"In what .md file should new tasks go? Leave blank to choose each time a new task is added. Start with a forward slash (/) for a full folder path. Otherwise, tasks go to specified path in the current folder."
 			)
 			.addText((text) => {
-				text.setPlaceholder("folder/file.md")
+				text.setPlaceholder("Tasks.md")
 					.setValue(this.settings.defaultTaskPath ?? "")
 					.onChange((value) => {
 						this.settings.defaultTaskPath = value;

--- a/src/ui/settings/settings_store.ts
+++ b/src/ui/settings/settings_store.ts
@@ -37,6 +37,7 @@ export const defaultSettings: SettingValues = {
 	consolidateTags: false,
 	uncategorizedVisibility: VisibilityOption.Auto,
 	doneVisibility: VisibilityOption.AlwaysShow,
+	defaultTaskPath: "Tasks.md",
 };
 
 export const createSettingsStore = () =>

--- a/src/ui/settings/settings_store.ts
+++ b/src/ui/settings/settings_store.ts
@@ -17,6 +17,7 @@ const settingsObject = z.object({
 	scope: z.nativeEnum(ScopeOption).default(ScopeOption.Folder),
 	showFilepath: z.boolean().default(true).optional(),
 	consolidateTags: z.boolean().default(false).optional(),
+	defaultTaskPath: z.string().optional(),
 	uncategorizedVisibility: z
 		.nativeEnum(VisibilityOption)
 		.default(VisibilityOption.Auto)

--- a/src/ui/tasks/actions.ts
+++ b/src/ui/tasks/actions.ts
@@ -101,8 +101,11 @@ export function createTaskActions({
 			if (defaultTaskPath && defaultTaskPath.trim()) {
 				const file = vault.getAbstractFileByPath(defaultTaskPath);
 				if (file instanceof TFile) {
-					updateRow(vault, file, undefined, `- [ ]  #${column}`);
-					return;
+					const exists = await vault.adapter.exists(file.path);
+					if (exists) {
+						updateRow(vault, file, undefined, `- [ ]  #${column}`);
+						return;
+					}
 				}
 			}
 

--- a/src/ui/tasks/actions.ts
+++ b/src/ui/tasks/actions.ts
@@ -109,12 +109,21 @@ export function createTaskActions({
 				const isAbsolutePath = /^[/\\]/.test(defaultTaskPath);
 
 				// If relative path, combine with current directory
-				const fullPath = isAbsolutePath
+				let fullPath = isAbsolutePath
 					? defaultTaskPath
 					: `${currentFilePath}/${defaultTaskPath}`.replace(
 							/\/+/g,
 							"/"
 					  );
+
+				// Add .md extension if needed
+				if (
+					!fullPath.endsWith("/") &&
+					!fullPath.endsWith("\\") &&
+					!fullPath.endsWith(".md")
+				) {
+					fullPath += ".md";
+				}
 
 				// Extract folder path from full file path
 				const folderPath = fullPath.substring(

--- a/src/ui/tasks/actions.ts
+++ b/src/ui/tasks/actions.ts
@@ -100,40 +100,56 @@ export function createTaskActions({
 			// Get configured default path from settings
 			const defaultTaskPath = get(settingsStore).defaultTaskPath;
 
-			if (defaultTaskPath?.trim()) {
+			const forbiddenCharacters = /[*\\"<>:|?]/;
+			console.log(defaultTaskPath);
+			if (
+				defaultTaskPath?.trim() &&
+				!forbiddenCharacters.test(defaultTaskPath)
+			) {
 				// Get the kanban board's directory path
 				const currentFilePath =
 					workspace.getActiveFile()?.parent?.path || "";
+				console.log("currentFilePath: " + currentFilePath);
 
-				// Determine if path is absolute (starts with / or \) or relative
-				const isAbsolutePath = /^[/\\]/.test(defaultTaskPath);
+				// Determine if path is absolute (starts with "/") or relative
+				const isAbsolutePath = defaultTaskPath.startsWith("/");
+				console.log(isAbsolutePath);
 
 				// If relative path, combine with current directory
 				let fullPath = isAbsolutePath
 					? defaultTaskPath
-					: `${currentFilePath}/${defaultTaskPath}`.replace(
-							/\/+/g,
-							"/"
-					  );
+					: `${currentFilePath}/${defaultTaskPath}`;
+
+				// Remove leading slashes, even if there are multiple
+				fullPath = fullPath.replace(/^\/+/, "");
+
+				// If path ends with "/", add default file
+				fullPath = fullPath.endsWith("/")
+					? fullPath + "Tasks.md"
+					: fullPath;
+
+				fullPath = fullPath.startsWith("//")
+					? fullPath.substring(1)
+					: fullPath;
 
 				// Add .md extension if needed
-				if (
-					!fullPath.endsWith("/") &&
-					!fullPath.endsWith("\\") &&
-					!fullPath.endsWith(".md")
-				) {
+				if (!fullPath.endsWith(".md")) {
 					fullPath += ".md";
 				}
+
+				console.log("fullpath na md:" + fullPath);
 
 				// Extract folder path from full file path
 				const folderPath = fullPath.substring(
 					0,
 					fullPath.lastIndexOf("/")
 				);
+				console.log("folderpath:" + folderPath);
 
 				// Create folder structure if needed
 				if (folderPath) {
 					const folderExists = await vault.adapter.exists(folderPath);
+					console.log("folderexists:" + folderExists);
 					if (!folderExists) {
 						await vault.createFolder(folderPath);
 					}
@@ -141,12 +157,15 @@ export function createTaskActions({
 
 				// Create the markdown file if needed
 				const exists = await vault.adapter.exists(fullPath);
+				console.log("exists:" + exists);
 				if (!exists) {
 					await vault.create(fullPath, "");
 				}
 
 				// Get file handle and validate it's a markdown file
 				const file = vault.getAbstractFileByPath(fullPath);
+				console.log(file);
+				console.log(file instanceof TFile);
 				if (file instanceof TFile) {
 					updateRow(vault, file, undefined, `- [ ]  #${column}`);
 					return;

--- a/src/ui/tasks/store.ts
+++ b/src/ui/tasks/store.ts
@@ -142,6 +142,7 @@ export function createTasksStore(
 		metadataByTaskId,
 		vault,
 		workspace,
+		settingsStore,
 	});
 
 	return { tasksStore, taskActions, initialise };


### PR DESCRIPTION
This adds a per-board default location to the settings. No more navigating the file menu every time you add a task! Unless you want to - keep the setting field empty to choose a location each time you add a file. If the specified file does not exist, it gets created. 

It defaults to Tasks.md, but works with existing boards that have no default location and has no unexpected behaviour there. i.e. existing boards with no default location set will not suddenly have a file added.

If a trailing slash is used, the file path is treated as an absolute path from the vault root, otherwise the folder the board is in  is used as root.

@chrskerr i am keeping this open in case you want to test this, i'm quite happy with this one! 😀